### PR TITLE
Add ftdetect and ftplugin

### DIFF
--- a/ftdetect/uwsc.vim
+++ b/ftdetect/uwsc.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.uws setfiletype uwsc

--- a/ftplugin/uwsc.vim
+++ b/ftplugin/uwsc.vim
@@ -1,0 +1,14 @@
+if exists('b:did_ftplugin')
+    finish
+endif
+let b:did_ftplugin = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+let b:undo_ftplugin = 'setlocal commentstring< comments<'
+
+setlocal commentstring=//\ %s
+setlocal comments=://
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
ftplugin enables to handle comment lines (starting with `//`) properly.